### PR TITLE
Simple speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ pipeline_info/*
 popgen-*
 202*
 .nextflow/*
+07.*
+05.*

--- a/conf/pca.config
+++ b/conf/pca.config
@@ -36,9 +36,9 @@ params {
 
 
 
-executor {
-    queueSize=500
-    submitRateLimit=10
+process {
+    executor = 'slurm'
+    queue = 'genomicsguestA'
+    clusterOptions = '-A b1042 -t 2:00:00 --mem=40G -e errlog.txt'
 }
-
 

--- a/main.nf
+++ b/main.nf
@@ -58,8 +58,8 @@ if(params.postgatk) {
 
 // check pca inputs
 if(params.pca && !params.postgatk) {
-    if(params.pops == null) error "Parameter --pops is required. Specify path to file"
-    if(params.anc == null) error "Parameter --anc is required. Specify ancestor strain"
+    // if(params.pops == null) error "Parameter --pops is required. Specify path to file"
+    // if(params.anc == null) error "Parameter --anc is required. Specify ancestor strain"
     if(params.eigen_ld == null) error "Parameter --eigen_ld is required. Specify LD value(s)"
     if(params.snv_vcf == null) error "Parameter --snv_vcf is required. Specify path to SNV-filtered VCF"
 }
@@ -207,19 +207,19 @@ workflow {
         }
 
         // extract ancestor
-        snv_vcf | extract_ancestor_bed
+        // snv_vcf | extract_ancestor_bed
 
         // annotate small vcf
-        snv_vcf 
-          .combine(extract_ancestor_bed.out)
-          .combine(pop_strains) | annotate_small_vcf 
+        // snv_vcf 
+         // .combine(extract_ancestor_bed.out)
+         // .combine(pop_strains) | annotate_small_vcf 
 
         ld_range = Channel.of("${params.eigen_ld}")
                       .splitCsv()
                       .flatMap { it }
 
         // make vcf for eigenstrat - use LD provided
-        annotate_small_vcf.out
+        snv_vcf
           .combine(ld_range) | vcf_to_eigstrat_files
 
         vcf_to_eigstrat_files.out

--- a/modules/pca.nf
+++ b/modules/pca.nf
@@ -158,11 +158,11 @@ process run_eigenstrat_no_outlier_removal {
   // conda '/projects/b1059/software/conda_envs/vcffixup'
 
   input:
-    tuple val("ld"), file("eigenstrat_input.ped"), file("eigenstrat_input.pedsnp"), file("eigenstrat_input.pedind"), file("plink.prune.in"), \
+    tuple val("test_ld"), file("eigenstrat_input.ped"), file("eigenstrat_input.pedsnp"), file("eigenstrat_input.pedind"), file("plink.prune.in"), \
     file ("markers.txt"), file ("sorted_samples.txt"), file(eigenparameters)
 
   output:
-    tuple val(ld), file("eigenstrat_no_removal.evac"), file("eigenstrat_no_removal.eval"), file("logfile_no_removal.txt"), \
+    tuple val(test_ld), file("eigenstrat_no_removal.evac"), file("eigenstrat_no_removal.eval"), file("logfile_no_removal.txt"), \
     file("eigenstrat_no_removal_relatedness"), file("eigenstrat_no_removal_relatedness.id"), file("TracyWidom_statistics_no_removal.tsv")
 
 
@@ -194,11 +194,11 @@ process run_eigenstrat_with_outlier_removal {
   publishDir "${params.output}/EIGESTRAT/LD_${test_ld}/OUTLIER_REMOVAL/", mode: 'copy'
 
   input:
-    tuple val("ld"), file("eigenstrat_input.ped"), file("eigenstrat_input.pedsnp"), file("eigenstrat_input.pedind"), file("plink.prune.in"), \
+    tuple val("test_ld"), file("eigenstrat_input.ped"), file("eigenstrat_input.pedsnp"), file("eigenstrat_input.pedind"), file("plink.prune.in"), \
     file ("markers.txt"), file ("sorted_samples.txt"), file(eigenparameters)
 
   output:
-    tuple val(ld), file("eigenstrat_outliers_removed.evac"), file("eigenstrat_outliers_removed.eval"), file("logfile_outlier.txt"), \
+    tuple val(test_ld), file("eigenstrat_outliers_removed.evac"), file("eigenstrat_outliers_removed.eval"), file("logfile_outlier.txt"), \
     file("eigenstrat_outliers_removed_relatedness"), file("eigenstrat_outliers_removed_relatedness.id"), file("TracyWidom_statistics_outlier_removal.tsv")
 
    
@@ -231,7 +231,7 @@ process HTML_report_PCA {
 
 
   input:
-  tuple val("ld"), file("eigenstrat_no_removal.evac"), file("eigenstrat_no_removal.eval"), file("logfile_no_removal.txt"), \
+  tuple val("test_ld"), file("eigenstrat_no_removal.evac"), file("eigenstrat_no_removal.eval"), file("logfile_no_removal.txt"), \
     file("eigenstrat_no_removal_relatedness"), file("eigenstrat_no_removal_relatedness.id"), file("TracyWidom_statistics_no_removal.tsv"), \
     file("eigenstrat_outliers_removed.evac"), file("eigenstrat_outliers_removed.eval"), file("logfile_outlier.txt"), \
     file("eigenstrat_outliers_removed_relatedness"), file("eigenstrat_outliers_removed_relatedness.id"), \
@@ -245,11 +245,11 @@ process HTML_report_PCA {
   """
   # prepare for report
   cat ${pca_report} | \\
-  sed "s+LD_VALUE+${ld}+" | \\
-  sed "s+EIGESTRAT/{ld}/NO_REMOVAL/++g" | \\
-  sed "s+EIGESTRAT/{ld}/OUTLIER_REMOVAL/++g" > pca_report_LD_${ld}.Rmd
+  sed "s+LD_VALUE+${test_ld}+" | \\
+  sed "s+EIGESTRAT/{test_ld}/NO_REMOVAL/++g" | \\
+  sed "s+EIGESTRAT/{test_ld}/OUTLIER_REMOVAL/++g" > pca_report_LD_${test_ld}.Rmd
 
-  Rscript -e "rmarkdown::render('pca_report_LD_${ld}.Rmd')"
+  Rscript -e "rmarkdown::render('pca_report_LD_${test_ld}.Rmd')"
   """
 
 

--- a/srun.txt
+++ b/srun.txt
@@ -1,0 +1,14 @@
+
+# Run an interactive BASH session on quest
+srun --account=b1042 \
+--partition=genomicsguestA \
+--time=03:00:00  \
+--mem=20G \
+--pty bash -l
+
+
+srun --account=b1042 \
+--partition=genomics \
+--time=03:00:00  \
+--mem=20G \
+--pty bash -l


### PR DESCRIPTION
Instead of using `bcftools` to make the `snpname` file used by `smartpca` i was able to just output a` plink .bim` file which allows us to just get the snps ids from these steps. 